### PR TITLE
Remove redundant app.UseAntiforgery() from Blazor Web templates

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Program.Main.cs
@@ -112,8 +112,6 @@ public class Program
         app.UseHttpsRedirection();
 
 #endif
-        app.UseAntiforgery();
-
         app.MapStaticAssets();
         #if (UseServer && UseWebAssembly)
         app.MapRazorComponents<App>()

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Program.cs
@@ -105,8 +105,6 @@ app.UseStatusCodePagesWithReExecute("/not-found", createScopeForStatusCodePages:
 app.UseHttpsRedirection();
 
 #endif
-app.UseAntiforgery();
-
 app.MapStaticAssets();
 #if (UseServer && UseWebAssembly)
 app.MapRazorComponents<App>()


### PR DESCRIPTION
Removes the explicit `app.UseAntiforgery();` call from the two `Program.cs` variants of the `BlazorWeb-CSharp` template. The call is now redundant in Blazor apps for two reasons:

1. **`CsrfProtectionMiddleware`** (auto-injected by `WebApplication.CreateBuilder` since #66585) blocks cross-site state-changing requests via `Sec-Fetch-Site` / `Origin` headers — covering the protection that `UseAntiforgery()` was previously providing for Blazor form posts in the template.
2. **The Razor Components endpoint invoker** no longer self-validates token-based antiforgery when the new CSRF middleware ran (companion change in this stack — base branch `dmkorolev/csrf-in-blazor`, PR #67082). The token-generation side is also gated on the legacy AF middleware actually running, so omitting `UseAntiforgery()` is internally consistent.

## Files changed

| File | Variant |
| --- | --- |
| `src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Program.cs` | Top-level statements |
| `src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Program.Main.cs` | `Main`-style |

Each file: 2 deletions (the `app.UseAntiforgery();` line plus the now-orphan blank line below it).

## Scope notes

A full-tree `grep "UseAntiforgery"` confirmed these are the **only** templates that call the method. No MVC, Razor Pages, Web API, or other Web templates touch antiforgery. Test assets and framework source intentionally left alone. In-tree samples (`src/Components/Samples/BlazorUnitedApp/Program.cs`, `src/Identity/samples/IdentitySample.PasskeyUI/Program.cs`) were initially included but reverted — the equivalent cleanup for sample apps belongs in `dotnet/AspNetCore.Docs.Samples`, not here.

`grep "Antiforgery" src/ProjectTemplates/test/` returns zero matches, so no snapshot/baseline test needs updating.

## Verification

- `dotnet build src/ProjectTemplates/Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj` → 0 errors / 0 warnings.
- Re-grep across `src/ProjectTemplates` confirms no `UseAntiforgery` references remain in template content.

## Companion PRs

- Base of this branch is `dmkorolev/csrf-in-blazor` (PR #67082) — the Razor Components endpoint invoker noop work that makes this safe.
- Upstream of that is #66585 — auto-injection of `CsrfProtectionMiddleware` into `WebApplication`.

Stacked PR; merge after PR #67082.